### PR TITLE
secret_elastic_readers default must be null

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "puppet_root_directory" {
 
 variable "secret_elastic_readers" {
   description = "List of role ARNs that will have permissions to read elastic superuser secret."
-  default     = []
+  default     = null
   type        = list(string)
 }
 


### PR DESCRIPTION
to avoid statements with empty principal
```
                  + {
                      + Action    = "secretsmanager:GetSecretValue"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = []
                        }
                      + Resource  = "*"
                    },

```
