### PR TITLE
Wait for green status and add implicit dependency

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -1,6 +1,6 @@
 module "update-dns" {
-  source  = "infrahouse/update-dns/aws"
-  version = "= 0.5.1"
+  source  = "registry.infrahouse.com/infrahouse/update-dns/aws"
+  version = "0.6.0"
   # insert the 2 required variables here
   asg_name          = var.cluster_name
   route53_zone_id   = data.aws_route53_zone.cluster.zone_id
@@ -8,8 +8,8 @@ module "update-dns" {
 }
 
 module "update-dns-data" {
-  source  = "infrahouse/update-dns/aws"
-  version = "= 0.5.1"
+  source  = "registry.infrahouse.com/infrahouse/update-dns/aws"
+  version = "0.6.0"
   # insert the 2 required variables here
   asg_name          = "${var.cluster_name}-data"
   route53_zone_id   = data.aws_route53_zone.cluster.zone_id


### PR DESCRIPTION
The cluster ASG depends on the DNS lambda. Because terraform cannot handle properly depends_on a module, the module tags the ASG with a lambda function name.
