### PR TITLE
Use backend_extra SG for transport

### DIFF
--- a/extra_security_group.tf
+++ b/extra_security_group.tf
@@ -9,12 +9,12 @@ resource "aws_security_group" "backend_extra" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "backend_extra_reserved" {
-  description       = "Elasticsearch ${var.cluster_name} transport"
-  security_group_id = aws_security_group.backend_extra.id
-  from_port         = 9300
-  to_port           = 9300
-  ip_protocol       = "tcp"
-  cidr_ipv4         = "0.0.0.0/0"
+  description                  = "Elasticsearch ${var.cluster_name} transport"
+  security_group_id            = aws_security_group.backend_extra.id
+  from_port                    = 9300
+  to_port                      = 9300
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.backend_extra.id
   tags = {
     Name = "Elasticsearch transport"
   }

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -38,13 +38,13 @@ def bootstrap_cluster(
             fp.write(
                 dedent(
                     f"""
-                    role_arn = "{TEST_ROLE_ARN}"
-                    region = "{REGION}"
+                    role_arn        = "{TEST_ROLE_ARN}"
+                    region          = "{REGION}"
                     elastic_zone_id = "{subzone_id}"
-                    bootstrap_mode = {str(bootstrap_mode).lower()}
+                    bootstrap_mode  = {str(bootstrap_mode).lower()}
 
-                    lb_subnet_ids = {json.dumps(subnet_public_ids)}
-                    backend_subnet_ids = {json.dumps(subnet_private_ids)}
+                    lb_subnet_ids       = {json.dumps(subnet_public_ids)}
+                    backend_subnet_ids  = {json.dumps(subnet_private_ids)}
                     internet_gateway_id = "{internet_gateway_id}"
                     """
                 )
@@ -79,13 +79,13 @@ def test_module(service_network, dns, ec2_client, route53_client, autoscaling_cl
             fp.write(
                 dedent(
                     f"""
-                    role_arn = "{TEST_ROLE_ARN}"
-                    region = "{REGION}"
+                    role_arn        = "{TEST_ROLE_ARN}"
+                    region          = "{REGION}"
                     elastic_zone_id = "{subzone_id}"
-                    bootstrap_mode = {str(bootstrap_mode).lower()}
+                    bootstrap_mode  = {str(bootstrap_mode).lower()}
 
-                    lb_subnet_ids = {json.dumps(subnet_public_ids)}
-                    backend_subnet_ids = {json.dumps(subnet_private_ids)}
+                    lb_subnet_ids       = {json.dumps(subnet_public_ids)}
+                    backend_subnet_ids  = {json.dumps(subnet_private_ids)}
                     internet_gateway_id = "{internet_gateway_id}"
                     """
                 )


### PR DESCRIPTION
The SG rules are the same - TCP/9300 but instead of 0.0.0.0/0, limit
traffic to originating from the SG backend_extra.
