### PR TITLE
Add variable monitoring_cidr_block

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ The module creates three endpoints to access the cluster. All three of them are 
 | [aws_secretsmanager_secret_version.kibana_system](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.backend_extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_ingress_rule.backend_extra_reserved](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.elastic_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.node_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [random_password.elastic](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.kibana_system](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_string.bucket_prefix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
@@ -186,6 +188,7 @@ The module creates three endpoints to access the cluster. All three of them are 
 | <a name="input_internet_gateway_id"></a> [internet\_gateway\_id](#input\_internet\_gateway\_id) | Not used, but AWS Internet Gateway must be present. Ensure by passing its id. | `string` | n/a | yes |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | SSH keypair name to be deployed in EC2 instances | `string` | n/a | yes |
 | <a name="input_max_instance_lifetime_days"></a> [max\_instance\_lifetime\_days](#input\_max\_instance\_lifetime\_days) | The maximum amount of time, in \_days\_, that an instance can be in service, values must be either equal to 0 or between 7 and 365 days. | `number` | `0` | no |
+| <a name="input_monitoring_cidr_block"></a> [monitoring\_cidr\_block](#input\_monitoring\_cidr\_block) | CIDR range that is allowed to monitor elastic instances. | `string` | `null` | no |
 | <a name="input_packages"></a> [packages](#input\_packages) | List of packages to install when the instances bootstraps. | `list(string)` | `[]` | no |
 | <a name="input_puppet_debug_logging"></a> [puppet\_debug\_logging](#input\_puppet\_debug\_logging) | Enable debug logging if true. | `bool` | `false` | no |
 | <a name="input_puppet_hiera_config_path"></a> [puppet\_hiera\_config\_path](#input\_puppet\_hiera\_config\_path) | Path to hiera configuration file. | `string` | `"{root_directory}/environments/{environment}/hiera.yaml"` | no |

--- a/extra_security_group.tf
+++ b/extra_security_group.tf
@@ -25,3 +25,36 @@ resource "aws_vpc_security_group_ingress_rule" "backend_extra_reserved" {
     local.default_module_tags
   )
 }
+
+
+resource "aws_vpc_security_group_ingress_rule" "node_exporter" {
+  count = var.monitoring_cidr_block == null ? 0 : 1
+  description                  = "Prometheus node exporter"
+  security_group_id            = aws_security_group.backend_extra.id
+  from_port                    = 9100
+  to_port                      = 9100
+  ip_protocol                  = "tcp"
+  cidr_ipv4 = var.monitoring_cidr_block
+  tags = merge(
+    {
+      Name = "Prometheus node exporter"
+    },
+    local.default_module_tags
+  )
+}
+
+resource "aws_vpc_security_group_ingress_rule" "elastic_exporter" {
+  count = var.monitoring_cidr_block == null ? 0 : 1
+  description                  = "Prometheus node exporter"
+  security_group_id            = aws_security_group.backend_extra.id
+  from_port                    = 9114
+  to_port                      = 9114
+  ip_protocol                  = "tcp"
+  cidr_ipv4 = var.monitoring_cidr_block
+  tags = merge(
+    {
+      Name = "Prometheus elsaticsearch exporter"
+    },
+    local.default_module_tags
+  )
+}

--- a/test_data/test_module/main.tf
+++ b/test_data/test_module/main.tf
@@ -15,6 +15,7 @@ module "test" {
   bootstrap_mode         = var.bootstrap_mode
   snapshot_bucket_prefix = "infrahouse-terraform-aws-elasticsearch"
   snapshot_force_destroy = true
+  monitoring_cidr_block  = "0.0.0.0/0"
   secret_elastic_readers = [
     "arn:aws:iam::${data.aws_caller_identity.this.account_id}:role/aws-reserved/sso.amazonaws.com/us-west-1/AWSReservedSSO_AWSAdministratorAccess_422821c726d81c14",
     "arn:aws:iam::990466748045:user/aleks"

--- a/variables.tf
+++ b/variables.tf
@@ -157,6 +157,12 @@ variable "ssh_cidr_block" {
   default     = "0.0.0.0/0"
 }
 
+variable "monitoring_cidr_block" {
+  description = "CIDR range that is allowed to monitor elastic instances."
+  type        = string
+  default     = null
+}
+
 variable "subnet_ids" {
   description = "List of subnet ids where the elasticsearch instances will be created"
   type        = list(string)


### PR DESCRIPTION
If specified, the module adds SG rules to allow monitoring systems to
query Prometheus exporters. The node on TCP/9100 and Elasticsearch exported
on TCP/9114.
