### PR TITLE
Elasticsearch cluster uses its own CA and self-signed certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The module creates three endpoints to access the cluster. All three of them are 
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.11 |
 | <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | ~> 2.3 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
@@ -129,17 +130,20 @@ The module creates three endpoints to access the cluster. All three of them are 
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.11 |
 | <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 5.11 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_elastic_cluster"></a> [elastic\_cluster](#module\_elastic\_cluster) | registry.infrahouse.com/infrahouse/website-pod/aws | 4.3.0 |
-| <a name="module_elastic_cluster_data"></a> [elastic\_cluster\_data](#module\_elastic\_cluster\_data) | registry.infrahouse.com/infrahouse/website-pod/aws | 4.3.0 |
+| <a name="module_ca_cert_secret"></a> [ca\_cert\_secret](#module\_ca\_cert\_secret) | registry.infrahouse.com/infrahouse/secret/aws | ~> 1.0 |
+| <a name="module_ca_key_secret"></a> [ca\_key\_secret](#module\_ca\_key\_secret) | registry.infrahouse.com/infrahouse/secret/aws | ~> 1.0 |
+| <a name="module_elastic_cluster"></a> [elastic\_cluster](#module\_elastic\_cluster) | registry.infrahouse.com/infrahouse/website-pod/aws | 5.0.0 |
+| <a name="module_elastic_cluster_data"></a> [elastic\_cluster\_data](#module\_elastic\_cluster\_data) | registry.infrahouse.com/infrahouse/website-pod/aws | 5.0.0 |
 | <a name="module_elastic_data_userdata"></a> [elastic\_data\_userdata](#module\_elastic\_data\_userdata) | registry.infrahouse.com/infrahouse/cloud-init/aws | 1.13.1 |
 | <a name="module_elastic_master_userdata"></a> [elastic\_master\_userdata](#module\_elastic\_master\_userdata) | registry.infrahouse.com/infrahouse/cloud-init/aws | 1.13.1 |
-| <a name="module_update-dns"></a> [update-dns](#module\_update-dns) | registry.infrahouse.com/infrahouse/update-dns/aws | 0.6.1 |
-| <a name="module_update-dns-data"></a> [update-dns-data](#module\_update-dns-data) | registry.infrahouse.com/infrahouse/update-dns/aws | 0.6.1 |
+| <a name="module_update-dns"></a> [update-dns](#module\_update-dns) | registry.infrahouse.com/infrahouse/update-dns/aws | 0.8.0 |
+| <a name="module_update-dns-data"></a> [update-dns-data](#module\_update-dns-data) | registry.infrahouse.com/infrahouse/update-dns/aws | 0.8.0 |
 
 ## Resources
 
@@ -159,6 +163,8 @@ The module creates three endpoints to access the cluster. All three of them are 
 | [random_password.kibana_system](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_string.bucket_prefix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.profile-suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [tls_private_key.ca_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_self_signed_cert.ca_cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [aws_ami.ubuntu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -180,8 +186,8 @@ The module creates three endpoints to access the cluster. All three of them are 
 | <a name="input_cluster_master_count"></a> [cluster\_master\_count](#input\_cluster\_master\_count) | Number of master nodes in the cluster | `number` | `3` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | How to name the cluster | `string` | `"elastic"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of environment. | `string` | `"development"` | no |
-| <a name="input_extra_files"></a> [extra\_files](#input\_extra\_files) | Additional files to create on an instance. | <pre>list(object({<br/>    content     = string<br/>    path        = string<br/>    permissions = string<br/>  }))</pre> | `[]` | no |
-| <a name="input_extra_repos"></a> [extra\_repos](#input\_extra\_repos) | Additional APT repositories to configure on an instance. | <pre>map(object({<br/>    source = string<br/>    key    = string<br/>  }))</pre> | `{}` | no |
+| <a name="input_extra_files"></a> [extra\_files](#input\_extra\_files) | Additional files to create on an instance. | <pre>list(object({<br>    content     = string<br>    path        = string<br>    permissions = string<br>  }))</pre> | `[]` | no |
+| <a name="input_extra_repos"></a> [extra\_repos](#input\_extra\_repos) | Additional APT repositories to configure on an instance. | <pre>map(object({<br>    source = string<br>    key    = string<br>  }))</pre> | `{}` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type to run the elasticsearch node | `string` | `"t3.medium"` | no |
 | <a name="input_instance_type_data"></a> [instance\_type\_data](#input\_instance\_type\_data) | Instance type to run the elasticsearch data node. If null, use var.instance\_type. | `string` | `null` | no |
 | <a name="input_instance_type_master"></a> [instance\_type\_master](#input\_instance\_type\_master) | Instance type to run the elasticsearch master node. If null, use var.instance\_type. | `string` | `null` | no |

--- a/dns.tf
+++ b/dns.tf
@@ -1,6 +1,6 @@
 module "update-dns" {
   source            = "registry.infrahouse.com/infrahouse/update-dns/aws"
-  version           = "0.6.1"
+  version           = "0.8.0"
   asg_name          = var.cluster_name
   route53_zone_id   = data.aws_route53_zone.cluster.zone_id
   route53_public_ip = false
@@ -8,7 +8,7 @@ module "update-dns" {
 
 module "update-dns-data" {
   source            = "registry.infrahouse.com/infrahouse/update-dns/aws"
-  version           = "0.6.1"
+  version           = "0.8.0"
   asg_name          = "${var.cluster_name}-data"
   route53_zone_id   = data.aws_route53_zone.cluster.zone_id
   route53_public_ip = false

--- a/iam.tf
+++ b/iam.tf
@@ -42,6 +42,8 @@ data "aws_iam_policy_document" "elastic_permissions" {
     resources = [
       aws_secretsmanager_secret.elastic.arn,
       aws_secretsmanager_secret.kibana_system.arn,
+      module.ca_cert_secret.secret_arn,
+      module.ca_key_secret.secret_arn,
     ]
   }
   statement {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ myst-parser ~= 2.0
 pytest-infrahouse ~= 0.3
 pytest-timeout ~= 2.1
 pytest-rerunfailures ~= 12.0
-requests ~= 2.31
+requests ~= 2.32

--- a/terraform.tf
+++ b/terraform.tf
@@ -17,5 +17,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
 }

--- a/tls.tf
+++ b/tls.tf
@@ -1,0 +1,57 @@
+# CA
+resource "tls_private_key" "ca_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+# Generate CA Certificate
+resource "tls_self_signed_cert" "ca_cert" {
+  private_key_pem   = tls_private_key.ca_key.private_key_pem
+  is_ca_certificate = true
+
+  subject {
+    common_name  = "InfraHouseCA"
+    organization = "InfraHouse"
+  }
+
+  validity_period_hours = 24 * 356 * 100
+  allowed_uses = [
+    "cert_signing",
+    "crl_signing"
+  ]
+}
+
+
+module "ca_key_secret" {
+  source             = "registry.infrahouse.com/infrahouse/secret/aws"
+  version            = "~> 1.0"
+  environment        = var.environment
+  secret_description = "CA secret key for cluster ${var.cluster_name}"
+  secret_name_prefix = "${var.cluster_name}-ca-key-"
+  secret_value       = tls_private_key.ca_key.private_key_pem
+  readers = concat(
+    [
+      module.elastic_cluster.instance_role_arn,
+    ],
+    var.bootstrap_mode ? [] : [
+      module.elastic_cluster_data[0].instance_role_arn,
+    ]
+  )
+}
+
+module "ca_cert_secret" {
+  source             = "registry.infrahouse.com/infrahouse/secret/aws"
+  version            = "~> 1.0"
+  environment        = var.environment
+  secret_description = "CA certificate for cluster ${var.cluster_name}"
+  secret_name_prefix = "${var.cluster_name}-ca-cert-"
+  secret_value       = tls_self_signed_cert.ca_cert.cert_pem
+  readers = concat(
+    [
+      module.elastic_cluster.instance_role_arn,
+    ],
+    var.bootstrap_mode ? [] : [
+      module.elastic_cluster_data[0].instance_role_arn,
+    ]
+  )
+}


### PR DESCRIPTION
* The cluster uses its own certificate and CA instead of Let's Encrypt
* To make it work, Terraform passes secret identifies ca_key_secret and ca_cert_secret as custom puppet facts
* Make sure puppet modules use this CA to issue self-signed certificates
* Use new version of update-dns module. It's more stable than old, it uses infrahouse-core classes in the lambda
* wobsite-pod requires TLS 1.2+
