### PR TITLE
Set default lifecycle hook action

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,31 +84,35 @@ module "elastic_data_userdata" {
 
 module "elastic_cluster" {
   source  = "registry.infrahouse.com/infrahouse/website-pod/aws"
-  version = "5.0.0"
+  version = "5.1.0"
   providers = {
     aws     = aws
     aws.dns = aws.dns
   }
-  service_name                          = local.service_name
-  asg_name                              = var.cluster_name
-  environment                           = var.environment
-  ami                                   = var.asg_ami != null ? var.asg_ami : data.aws_ami.ubuntu.image_id
-  subnets                               = var.subnet_ids
-  backend_subnets                       = var.subnet_ids
-  zone_id                               = var.zone_id
-  internet_gateway_id                   = var.internet_gateway_id
-  key_pair_name                         = var.key_pair_name
-  ssh_cidr_block                        = var.ssh_cidr_block
-  dns_a_records                         = [var.cluster_name, "${var.cluster_name}-master"]
-  alb_name_prefix                       = substr(var.cluster_name, 0, 6) ## "name_prefix" cannot be longer than 6 characters: "elastic"
-  userdata                              = module.elastic_master_userdata.userdata
-  instance_profile_permissions          = data.aws_iam_policy_document.elastic_permissions.json
-  stickiness_enabled                    = true
-  asg_min_size                          = var.bootstrap_mode ? 1 : var.cluster_master_count
-  asg_max_size                          = var.bootstrap_mode ? 1 : var.cluster_master_count
-  asg_lifecycle_hook_initial            = var.asg_create_initial_lifecycle_hook ? module.update-dns.lifecycle_name_launching : null
-  asg_lifecycle_hook_launching          = module.update-dns.lifecycle_name_launching
-  asg_lifecycle_hook_terminating        = module.update-dns.lifecycle_name_terminating
+  service_name                 = local.service_name
+  asg_name                     = var.cluster_name
+  environment                  = var.environment
+  ami                          = var.asg_ami != null ? var.asg_ami : data.aws_ami.ubuntu.image_id
+  subnets                      = var.subnet_ids
+  backend_subnets              = var.subnet_ids
+  zone_id                      = var.zone_id
+  internet_gateway_id          = var.internet_gateway_id
+  key_pair_name                = var.key_pair_name
+  ssh_cidr_block               = var.ssh_cidr_block
+  dns_a_records                = [var.cluster_name, "${var.cluster_name}-master"]
+  alb_name_prefix              = substr(var.cluster_name, 0, 6) ## "name_prefix" cannot be longer than 6 characters: "elastic"
+  userdata                     = module.elastic_master_userdata.userdata
+  instance_profile_permissions = data.aws_iam_policy_document.elastic_permissions.json
+  stickiness_enabled           = true
+
+  asg_min_size                                  = var.bootstrap_mode ? 1 : var.cluster_master_count
+  asg_max_size                                  = var.bootstrap_mode ? 1 : var.cluster_master_count
+  asg_lifecycle_hook_initial                    = var.asg_create_initial_lifecycle_hook ? module.update-dns.lifecycle_name_launching : null
+  asg_lifecycle_hook_launching                  = module.update-dns.lifecycle_name_launching
+  asg_lifecycle_hook_terminating                = module.update-dns.lifecycle_name_terminating
+  asg_lifecycle_hook_launching_default_result   = "ABANDON"
+  asg_lifecycle_hook_terminating_default_result = "CONTINUE"
+
   max_instance_lifetime_days            = var.max_instance_lifetime_days
   instance_type                         = var.instance_type_master != null ? var.instance_type_master : var.instance_type
   health_check_type                     = "EC2"
@@ -142,31 +146,35 @@ module "elastic_cluster_data" {
   # Deploy only if not in the bootstrap mode
   count   = var.bootstrap_mode ? 0 : 1
   source  = "registry.infrahouse.com/infrahouse/website-pod/aws"
-  version = "5.0.0"
+  version = "5.1.0"
   providers = {
     aws     = aws
     aws.dns = aws.dns
   }
-  service_name                          = local.service_name
-  asg_name                              = "${var.cluster_name}-data"
-  environment                           = var.environment
-  ami                                   = var.asg_ami != null ? var.asg_ami : data.aws_ami.ubuntu.image_id
-  subnets                               = var.subnet_ids
-  backend_subnets                       = var.subnet_ids
-  zone_id                               = var.zone_id
-  internet_gateway_id                   = var.internet_gateway_id
-  key_pair_name                         = var.key_pair_name
-  ssh_cidr_block                        = var.ssh_cidr_block
-  dns_a_records                         = ["${var.cluster_name}-data"]
-  alb_name_prefix                       = substr(var.cluster_name, 0, 6) ## "name_prefix" cannot be longer than 6 characters: "elastic"
-  userdata                              = module.elastic_data_userdata.userdata
-  instance_profile_permissions          = data.aws_iam_policy_document.elastic_permissions.json
-  stickiness_enabled                    = true
-  asg_min_size                          = var.cluster_data_count
-  asg_max_size                          = var.cluster_data_count
-  asg_lifecycle_hook_initial            = var.asg_create_initial_lifecycle_hook ? module.update-dns.lifecycle_name_launching : null
-  asg_lifecycle_hook_launching          = module.update-dns-data.lifecycle_name_launching
-  asg_lifecycle_hook_terminating        = module.update-dns-data.lifecycle_name_terminating
+  service_name                 = local.service_name
+  asg_name                     = "${var.cluster_name}-data"
+  environment                  = var.environment
+  ami                          = var.asg_ami != null ? var.asg_ami : data.aws_ami.ubuntu.image_id
+  subnets                      = var.subnet_ids
+  backend_subnets              = var.subnet_ids
+  zone_id                      = var.zone_id
+  internet_gateway_id          = var.internet_gateway_id
+  key_pair_name                = var.key_pair_name
+  ssh_cidr_block               = var.ssh_cidr_block
+  dns_a_records                = ["${var.cluster_name}-data"]
+  alb_name_prefix              = substr(var.cluster_name, 0, 6) ## "name_prefix" cannot be longer than 6 characters: "elastic"
+  userdata                     = module.elastic_data_userdata.userdata
+  instance_profile_permissions = data.aws_iam_policy_document.elastic_permissions.json
+  stickiness_enabled           = true
+
+  asg_min_size                                  = var.cluster_data_count
+  asg_max_size                                  = var.cluster_data_count
+  asg_lifecycle_hook_initial                    = var.asg_create_initial_lifecycle_hook ? module.update-dns.lifecycle_name_launching : null
+  asg_lifecycle_hook_launching                  = module.update-dns-data.lifecycle_name_launching
+  asg_lifecycle_hook_terminating                = module.update-dns-data.lifecycle_name_terminating
+  asg_lifecycle_hook_launching_default_result   = "ABANDON"
+  asg_lifecycle_hook_terminating_default_result = "CONTINUE"
+
   max_instance_lifetime_days            = var.max_instance_lifetime_days
   health_check_type                     = "EC2"
   instance_type                         = var.instance_type_data != null ? var.instance_type_data : var.instance_type


### PR DESCRIPTION
* When launching, we don't want to put an instance into the cluster if the DNS update failed. Even if we did, TLS internode communication will fail.
* When terminating, we want the instance to complete decommissioning even if the DNS update failed.
