### PR TITLE
Bring back terminating lifecycle hook

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -1,17 +1,15 @@
 module "update-dns" {
-  source                              = "registry.infrahouse.com/infrahouse/update-dns/aws"
-  version                             = "0.9.0"
-  asg_name                            = var.cluster_name
-  route53_zone_id                     = data.aws_route53_zone.cluster.zone_id
-  route53_public_ip                   = false
-  complete_terminating_lifecycle_hook = false
+  source            = "registry.infrahouse.com/infrahouse/update-dns/aws"
+  version           = "0.9.0"
+  asg_name          = var.cluster_name
+  route53_zone_id   = data.aws_route53_zone.cluster.zone_id
+  route53_public_ip = false
 }
 
 module "update-dns-data" {
-  source                              = "registry.infrahouse.com/infrahouse/update-dns/aws"
-  version                             = "0.9.0"
-  asg_name                            = "${var.cluster_name}-data"
-  route53_zone_id                     = data.aws_route53_zone.cluster.zone_id
-  route53_public_ip                   = false
-  complete_terminating_lifecycle_hook = false
+  source            = "registry.infrahouse.com/infrahouse/update-dns/aws"
+  version           = "0.9.0"
+  asg_name          = "${var.cluster_name}-data"
+  route53_zone_id   = data.aws_route53_zone.cluster.zone_id
+  route53_public_ip = false
 }

--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ module "elastic_cluster_data" {
 
   asg_min_size                                  = var.cluster_data_count
   asg_max_size                                  = var.cluster_data_count
-  asg_lifecycle_hook_initial                    = var.asg_create_initial_lifecycle_hook ? module.update-dns.lifecycle_name_launching : null
+  asg_lifecycle_hook_initial                    = var.asg_create_initial_lifecycle_hook ? module.update-dns-data.lifecycle_name_launching : null
   asg_lifecycle_hook_launching                  = module.update-dns-data.lifecycle_name_launching
   asg_lifecycle_hook_terminating                = module.update-dns-data.lifecycle_name_terminating
   asg_lifecycle_hook_launching_default_result   = "ABANDON"
@@ -197,4 +197,12 @@ module "elastic_cluster_data" {
     cluster : var.cluster_name
     elastic_role : "data"
   }
+}
+
+resource "aws_autoscaling_lifecycle_hook" "terminating" {
+  count   = var.bootstrap_mode ? 0 : 1
+  autoscaling_group_name = module.elastic_cluster_data[0].asg_name
+  lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"
+  name                   = "terminating"
+  default_result         = "CONTINUE"
 }

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,6 +1,4 @@
-import contextlib
 import json
-import os
 from os import path as osp
 from textwrap import dedent
 
@@ -29,7 +27,9 @@ def test_module(
 
     # Bootstrap ES cluster
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "test_module")
-    with bootstrap_cluster(service_network, dns, keep_after, aws_region, test_role_arn):
+    with bootstrap_cluster(
+        service_network, dns, keep_after, aws_region, test_role_arn, "test_module"
+    ):
         # Create remaining master & data nodes
         bootstrap_mode = False
         with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:


### PR DESCRIPTION
Each of created lifecycle hooks (if more than one) have to be completed individually.
That's why bringing back "terminating" that is completed when a node is decommissioned.
The update-dns hooks have to be completed, too.
