### PR TITLE
Fix: Bucket name must not contain uppercase characters

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The size of the autoscaling group will be not three, but one node.
 module "test" {
   module "test" {
     source  = "registry.infrahouse.com/infrahouse/elasticsearch/aws"
-    version = "3.1.0"
+    version = "3.1.1"
     
     providers = {
       aws     = aws

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
   service_name   = var.cluster_name
-  module_version = "3.1.0"
+  module_version = "3.1.1"
 
   default_module_tags = {
     environment : var.environment

--- a/s3.tf
+++ b/s3.tf
@@ -2,6 +2,7 @@ resource "random_string" "bucket_prefix" {
   length  = 12
   special = false
   numeric = false
+  upper   = false
 }
 
 locals {


### PR DESCRIPTION
- **Fix: Bucket name must not contain uppercase characters**
- **Bump version: 3.1.0 → 3.1.1**
