### PR TITLE
Ensure update-dns lambda is created before ASG. Otherwise, bootstrap fails

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -150,6 +150,7 @@ module "elastic_cluster" {
     Name : "${var.cluster_name} master node"
     cluster : var.cluster_name
     elastic_role : "master"
+    update_dns_lambda : module.update-dns.lambda_name
   }
 }
 
@@ -213,6 +214,7 @@ module "elastic_cluster_data" {
     Name : "${var.cluster_name} data node"
     cluster : var.cluster_name
     elastic_role : "data"
+    update_dns_lambda : module.update-dns-data.lambda_name
   }
 }
 


### PR DESCRIPTION
```
2025-05-25 19:24:49,903: 1681519: INFO: tests.conftest:conftest.bootstrap_cluster():93: Will keep test_data/test_module/.bootstrapped around because we're keeping resources after the test.
PASSED

==================================================================== 1 passed in 897.64s (0:14:57) =====================================================================
```