### PR TITLE
feat: update extra_repos variable to match infrahouse/cloud-init/aws v2.2.2

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -58,10 +58,17 @@ variable "extra_files" {
 
 variable "extra_repos" {
   description = "Additional APT repositories to configure on an instance."
-  type = map(object({
-    source = string
-    key    = string
-  }))
+  type = map(
+    object(
+      {
+        source   = string
+        key      = string
+        machine  = optional(string)
+        authFrom = optional(string)
+        priority = optional(number)
+      }
+    )
+  )
   default = {}
 }
 


### PR DESCRIPTION
Update extra_repos variable type to match the corresponding variable in infrahouse/cloud-init/aws v2.2.2, adding optional fields: machine, authFrom, and priority.
