### PR TITLE
fix: bump update-dns module to 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,8 +511,8 @@ See the [Outputs](#outputs) section for complete output documentation.
 | <a name="module_elastic_master_userdata"></a> [elastic\_master\_userdata](#module\_elastic\_master\_userdata) | registry.infrahouse.com/infrahouse/cloud-init/aws | 2.4.0 |
 | <a name="module_kibana_system-password"></a> [kibana\_system-password](#module\_kibana\_system-password) | registry.infrahouse.com/infrahouse/secret/aws | 1.1.1 |
 | <a name="module_snapshots_bucket"></a> [snapshots\_bucket](#module\_snapshots\_bucket) | registry.infrahouse.com/infrahouse/s3-bucket/aws | 0.6.0 |
-| <a name="module_update-dns"></a> [update-dns](#module\_update-dns) | registry.infrahouse.com/infrahouse/update-dns/aws | 1.4.0 |
-| <a name="module_update-dns-data"></a> [update-dns-data](#module\_update-dns-data) | registry.infrahouse.com/infrahouse/update-dns/aws | 1.4.0 |
+| <a name="module_update-dns"></a> [update-dns](#module\_update-dns) | registry.infrahouse.com/infrahouse/update-dns/aws | 1.5.1 |
+| <a name="module_update-dns-data"></a> [update-dns-data](#module\_update-dns-data) | registry.infrahouse.com/infrahouse/update-dns/aws | 1.5.1 |
 
 ## Resources
 

--- a/dns.tf
+++ b/dns.tf
@@ -1,6 +1,6 @@
 module "update-dns" {
   source            = "registry.infrahouse.com/infrahouse/update-dns/aws"
-  version           = "1.4.0"
+  version           = "1.5.1"
   asg_name          = var.cluster_name
   route53_zone_id   = data.aws_route53_zone.cluster.zone_id
   route53_public_ip = false
@@ -12,7 +12,7 @@ module "update-dns" {
 
 module "update-dns-data" {
   source            = "registry.infrahouse.com/infrahouse/update-dns/aws"
-  version           = "1.4.0"
+  version           = "1.5.1"
   asg_name          = "${var.cluster_name}-data"
   route53_zone_id   = data.aws_route53_zone.cluster.zone_id
   route53_public_ip = false


### PR DESCRIPTION
## Summary

Bumps both `update-dns` module instances in `dns.tf` from `1.4.0` to `1.5.1` to adopt the cryptography floor security fix.

The fix pins `cryptography >= 48.0.1` in the lambda deps to avoid statically-linked vulnerable OpenSSL ([GHSA-537c-gmf6-5ccf](https://github.com/advisories/GHSA-537c-gmf6-5ccf)), pulled in transitively via `infrahouse-core -> PyGithub -> PyJWT`.

- Adopts [infrahouse/terraform-aws-update-dns#48](https://github.com/infrahouse/terraform-aws-update-dns/pull/48), released in [1.5.1](https://github.com/infrahouse/terraform-aws-update-dns/releases/tag/1.5.1)
- Also picks up 1.5.0: re-raise in lifecycle handler instead of muting exceptions, and skip DNS for warm-pool lifecycle transitions

No breaking changes and no new required inputs between 1.4.0 and 1.5.1, so existing arguments are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)